### PR TITLE
Add toggle for streamlined apparel stats

### DIFF
--- a/1.6/Source/ZealousInnocence/Apparel/ApparelStatManager.cs
+++ b/1.6/Source/ZealousInnocence/Apparel/ApparelStatManager.cs
@@ -1,0 +1,227 @@
+using RimWorld;
+using System.Collections.Generic;
+using System.Linq;
+using Verse;
+
+namespace ZealousInnocence
+{
+    [StaticConstructorOnStartup]
+    public static class ApparelStatManager
+    {
+        private static Dictionary<ThingDef, List<StatModifier>> originalOffsets = new Dictionary<ThingDef, List<StatModifier>>();
+        private static Dictionary<ThingDef, List<StatModifier>> streamlinedOffsets = new Dictionary<ThingDef, List<StatModifier>>();
+
+        static ApparelStatManager()
+        {
+            Initialize();
+        }
+
+        public static void Initialize()
+        {
+            // Resolve all apparel defs
+            var defs = new Dictionary<string, ThingDef>();
+            string[] defNames = new string[]
+            {
+                "Apparel_Diaper_Flimsy",
+                "Apparel_Diaper_Night",
+                "Apparel_Diaper",
+                "Apparel_Premium_Diaper",
+                "Apparel_Diaper_BabyDiaper",
+                "Apparel_Diaper_Disposable",
+                "Apparel_Simplie",
+                "Apparel_Onesie",
+                "Apparel_Gunsie",
+                "ZI_Pacifier",
+                "Apparel_Underwear_Loincloth",
+                "Apparel_Underwear_Kids",
+                "Apparel_Underwear_Boxers",
+                "Apparel_Underwear_Panties",
+            };
+
+            foreach (var name in defNames)
+            {
+                var def = DefDatabase<ThingDef>.GetNamedSilentFail(name);
+                if (def != null)
+                    defs[name] = def;
+                else
+                    Log.Warning($"[ZI] ApparelStatManager: Could not find ThingDef '{name}'");
+            }
+
+            // Cache original offsets (deep copy)
+            foreach (var kvp in defs)
+            {
+                var def = kvp.Value;
+                if (def.equippedStatOffsets != null)
+                    originalOffsets[def] = def.equippedStatOffsets.Select(s => new StatModifier { stat = s.stat, value = s.value }).ToList();
+                else
+                    originalOffsets[def] = new List<StatModifier>();
+            }
+
+            // Build streamlined offsets
+            // Stats that may not exist without DLC
+            var slaveSuppression = DefDatabase<StatDef>.GetNamedSilentFail("SlaveSuppressionOffset");
+            var suppressionPower = DefDatabase<StatDef>.GetNamedSilentFail("SuppressionPower");
+            var diaperSupport = DefDatabase<StatDef>.GetNamedSilentFail("DiaperSupport");
+
+            // 1. Flimsy Diaper
+            if (defs.TryGetValue("Apparel_Diaper_Flimsy", out var flimsyDiaper))
+            {
+                var list = new List<StatModifier>
+                {
+                    MakeStat(RimWorld.StatDefOf.MoveSpeed, -0.08f),
+                    MakeStat(RimWorld.StatDefOf.MeleeDodgeChance, -0.05f),
+                    MakeStat(RimWorld.StatDefOf.PawnTrapSpringChance, 0.03f),
+                    MakeStat(RimWorld.StatDefOf.HuntingStealth, -0.05f),
+                };
+                AddIfExists(list, slaveSuppression, 0.2f);
+                streamlinedOffsets[flimsyDiaper] = list;
+            }
+
+            // 2. Pull-ups (Night)
+            if (defs.TryGetValue("Apparel_Diaper_Night", out var nightDiaper))
+            {
+                var list = new List<StatModifier>
+                {
+                    MakeStat(RimWorld.StatDefOf.HuntingStealth, -0.01f),
+                };
+                AddIfExists(list, slaveSuppression, 0.1f);
+                streamlinedOffsets[nightDiaper] = list;
+            }
+
+            // 3. Diaper
+            if (defs.TryGetValue("Apparel_Diaper", out var diaper))
+            {
+                var list = new List<StatModifier>
+                {
+                    MakeStat(RimWorld.StatDefOf.MoveSpeed, -0.08f),
+                    MakeStat(RimWorld.StatDefOf.MeleeDodgeChance, -0.05f),
+                    MakeStat(RimWorld.StatDefOf.PawnTrapSpringChance, 0.03f),
+                    MakeStat(RimWorld.StatDefOf.HuntingStealth, -0.03f),
+                };
+                AddIfExists(list, slaveSuppression, 0.1f);
+                streamlinedOffsets[diaper] = list;
+            }
+
+            // 4. Premium Diaper
+            if (defs.TryGetValue("Apparel_Premium_Diaper", out var premiumDiaper))
+            {
+                var list = new List<StatModifier>
+                {
+                    MakeStat(RimWorld.StatDefOf.MentalBreakThreshold, -0.05f),
+                    MakeStat(RimWorld.StatDefOf.MoveSpeed, -0.01f),
+                };
+                AddIfExists(list, slaveSuppression, 0.15f);
+                streamlinedOffsets[premiumDiaper] = list;
+            }
+
+            // 5. Baby Diaper
+            if (defs.TryGetValue("Apparel_Diaper_BabyDiaper", out var babyDiaper))
+            {
+                var list = new List<StatModifier>
+                {
+                    MakeStat(RimWorld.StatDefOf.MoveSpeed, -0.02f),
+                };
+                streamlinedOffsets[babyDiaper] = list;
+            }
+
+            // 6. Disposable Diaper
+            if (defs.TryGetValue("Apparel_Diaper_Disposable", out var disposableDiaper))
+            {
+                var list = new List<StatModifier>
+                {
+                    MakeStat(RimWorld.StatDefOf.MoveSpeed, -0.04f),
+                };
+                streamlinedOffsets[disposableDiaper] = list;
+            }
+
+            // 7. Simplie
+            if (defs.TryGetValue("Apparel_Simplie", out var simplie))
+            {
+                var list = new List<StatModifier>
+                {
+                    MakeStat(RimWorld.StatDefOf.MoveSpeed, 0.1f),
+                };
+                AddIfExists(list, slaveSuppression, 0.2f);
+                streamlinedOffsets[simplie] = list;
+            }
+
+            // 8. Onesie
+            if (defs.TryGetValue("Apparel_Onesie", out var onesie))
+            {
+                var list = new List<StatModifier>
+                {
+                    MakeStat(RimWorld.StatDefOf.MoveSpeed, 0.1f),
+                };
+                AddIfExists(list, slaveSuppression, 0.1f);
+                streamlinedOffsets[onesie] = list;
+            }
+
+            // 9. Worksie — NO CHANGES (excluded from streamlined dict)
+
+            // 10. Gunsie
+            if (defs.TryGetValue("Apparel_Gunsie", out var gunsie))
+            {
+                var list = new List<StatModifier>
+                {
+                    MakeStat(RimWorld.StatDefOf.MoveSpeed, 0.1f),
+                    MakeStat(RimWorld.StatDefOf.MeleeDodgeChance, 0.4f),
+                };
+                AddIfExists(list, diaperSupport, 0.4f);
+                AddIfExists(list, suppressionPower, 0.08f);
+                streamlinedOffsets[gunsie] = list;
+            }
+
+            // 11. Pacifier
+            if (defs.TryGetValue("ZI_Pacifier", out var pacifier))
+            {
+                var list = new List<StatModifier>
+                {
+                    MakeStat(RimWorld.StatDefOf.MentalBreakThreshold, -0.1f),
+                    MakeStat(RimWorld.StatDefOf.NegotiationAbility, -0.15f),
+                    MakeStat(RimWorld.StatDefOf.TradePriceImprovement, -0.15f),
+                };
+                AddIfExists(list, slaveSuppression, 0.15f);
+                streamlinedOffsets[pacifier] = list;
+            }
+
+            // 12-15. All underwear — empty lists
+            string[] underwearNames = { "Apparel_Underwear_Loincloth", "Apparel_Underwear_Kids", "Apparel_Underwear_Boxers", "Apparel_Underwear_Panties" };
+            foreach (var name in underwearNames)
+            {
+                if (defs.TryGetValue(name, out var underwear))
+                    streamlinedOffsets[underwear] = new List<StatModifier>();
+            }
+
+            // Apply based on current setting
+            Apply();
+
+            Log.Message("[ZI] ApparelStatManager initialized.");
+        }
+
+        public static void Apply()
+        {
+            var settings = LoadedModManager.GetMod<ZealousInnocence>().GetSettings<ZealousInnocenceSettings>();
+            bool streamlined = settings.streamlinedApparelStats;
+
+            foreach (var kvp in originalOffsets)
+            {
+                var def = kvp.Key;
+                if (streamlined && streamlinedOffsets.ContainsKey(def))
+                    def.equippedStatOffsets = streamlinedOffsets[def];
+                else
+                    def.equippedStatOffsets = kvp.Value;
+            }
+        }
+
+        private static StatModifier MakeStat(StatDef stat, float value)
+        {
+            return new StatModifier { stat = stat, value = value };
+        }
+
+        private static void AddIfExists(List<StatModifier> list, StatDef stat, float value)
+        {
+            if (stat != null)
+                list.Add(MakeStat(stat, value));
+        }
+    }
+}

--- a/1.6/Source/ZealousInnocence/ZealousInnocenceSettings.cs
+++ b/1.6/Source/ZealousInnocence/ZealousInnocenceSettings.cs
@@ -21,6 +21,8 @@ namespace ZealousInnocence
         //public bool formerAdultsCanHaveIdeoRoles = true;
         public bool bladderForRaidCaravanVisitors = true;
 
+        public bool streamlinedApparelStats = false;
+
         public bool dynamicGenetics = true;
         public float adultBedwetters = 0.05f;
 
@@ -128,7 +130,8 @@ namespace ZealousInnocence
             Scribe_Values.Look(ref formerAdultsNeedLearning, "formerAdultsNeedLearning", true);
             Scribe_Values.Look(ref formerAdultsCanHaveIdeoRoles, "formerAdultsCanHaveIdeoRoles", true);*/
             Scribe_Values.Look(ref bladderForRaidCaravanVisitors, "bladderForRaidCaravanVisitors", true);
-            
+
+            Scribe_Values.Look(ref streamlinedApparelStats, "streamlinedApparelStats", false);
 
             Scribe_Values.Look(ref dynamicGenetics, "dynamicGenetics", true);
             Scribe_Values.Look(ref adultBedwetters, "adultBedwetters", 0.05f);
@@ -288,6 +291,12 @@ namespace ZealousInnocence
             list.GapLine(gabSize);
             list.TextEntry("SettingRequiresRestart".Translate());
             list.CheckboxLabeled("SettingEnableBladderForRaidVisitorCaravans".Translate(), ref bladderForRaidCaravanVisitors, "SettingEnableBladderForRaidVisitorCaravansHelp".Translate());
+
+            list.GapLine(gabSize);
+            bool prevStreamlined = streamlinedApparelStats;
+            list.CheckboxLabeled("SettingStreamlinedApparel".Translate(), ref streamlinedApparelStats, "SettingStreamlinedApparelHelp".Translate());
+            if (prevStreamlined != streamlinedApparelStats)
+                ApparelStatManager.Apply();
 
             this.list.NewColumn();
             this.list.ColumnWidth = (canvas.width - 40f) * 0.33f;

--- a/Languages/English/Keyed/Settings.xml
+++ b/Languages/English/Keyed/Settings.xml
@@ -181,6 +181,10 @@
 	<SettingDebugNeeds>DEBUG Needs</SettingDebugNeeds>
   <SettingDebugNeedsHelp>Needs like bladder, play/learn/joy or diaper have overlap with capacities. But this debugging specifically targets the adding, removing and ticking of a need and not any resulting capacity.</SettingDebugNeedsHelp>
 	
+  <!-- Apparel Stats -->
+  <SettingStreamlinedApparel>Disable most apparel special offsets</SettingStreamlinedApparel>
+  <SettingStreamlinedApparelHelp>With this setting on, apparels from this mod, like diapers, onesies and underwear, will have less bloated stats, mostly affecting physical stats like movespeed instead of mood management and psychic sensitivity, for a more balanced but less roleplayful gameplay.</SettingStreamlinedApparelHelp>
+
   <!-- Buttons -->
   <SettingCheckForeverYoung>Check 'ForeverYoung' active</SettingCheckForeverYoung>
   <SettingForeverYoungActive>'ForeverYoung' IS active!</SettingForeverYoungActive>


### PR DESCRIPTION
Introduce a setting to toggle streamlined apparel stats, reducing the impact of certain apparel on physical stats to priorittize balance in gameplay instead of flavor. This change allows for a less impactful stat offsets, for those who prefer it. The toggle will be off by default.